### PR TITLE
Add the possibility to overwrite CA certs

### DIFF
--- a/helm/estafette-vulnerability-scanner/templates/configmap.yaml
+++ b/helm/estafette-vulnerability-scanner/templates/configmap.yaml
@@ -5,3 +5,16 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "estafette-vulnerability-scanner.labels" . | nindent 4 }}
+{{- if .Values.caCerts }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "estafette-vulnerability-scanner.fullname" . }}-cacerts
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "estafette-vulnerability-scanner.labels" . | nindent 4 }}
+data:
+  ca-certificates.crt:
+  {{- toYaml .Values.caCerts | indent 4 }}
+{{- end }}

--- a/helm/estafette-vulnerability-scanner/templates/deployment.yaml
+++ b/helm/estafette-vulnerability-scanner/templates/deployment.yaml
@@ -69,11 +69,21 @@ spec:
         volumeMounts:
         - name: state-file
           mountPath: /state
+        {{- if .Values.caCerts }}
+        - name: cacerts
+          mountPath: /etc/ssl/certs/ca-certificates.crt
+          subPath: ca-certificates.crt
+        {{- end }}
       terminationGracePeriodSeconds: 300
       volumes:
       - name: state-file
         configMap:
           name: {{ include "estafette-vulnerability-scanner.fullname" . }}-state
+      {{- if .Values.caCerts }}
+      - name: cacerts
+        configMap:
+          name: {{ include "estafette-vulnerability-scanner.fullname" . }}-cacerts
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/estafette-vulnerability-scanner/templates/deployment.yaml
+++ b/helm/estafette-vulnerability-scanner/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
             value: "{{ .Release.Name }}"
           {{- range $key, $value := .Values.extraEnv }}
           - name: {{ $key }}
-            value: {{ $value }}
+            value: {{ $value | quote }}
           {{- end }}
         ports:
           - name: metrics

--- a/helm/estafette-vulnerability-scanner/values.yaml
+++ b/helm/estafette-vulnerability-scanner/values.yaml
@@ -106,3 +106,17 @@ extraLabels: {}
 
 # use to add extra labels to podspec for getting their values in prometheus
 extraPodLabels: {}
+
+# use to overwrite default CA certificates with your own
+# e.g :
+# caCerts: |
+#  ----- BEGIN CERTIFICATE -----
+#  MIID7zCCAtegAwIBAgIBADANBgkqhkiG9w0BAQsFADCBmDELMAkGA1UEBhMCVVMx
+#  EDA....
+#  ...
+#  ----- END CERTIFICATE -----
+#  ----- BEGIN CERTIFICATE -----
+#  .....
+#  ----- END CERTIFICATE -----
+#
+# caCerts:


### PR DESCRIPTION
Some environments require own CA to work. This allows, via values, to set the
ca-certificates file properly.